### PR TITLE
Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM debian 
 
 RUN apt-get update && apt-get install -y net-tools less curl vim tar gzip ruby openvpn easy-rsa libpam-google-authenticator libpam-radius-auth freeradius-utils 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   openvpn:
     image: croc/openvpn
     environment:
-      - SERVER_ADDRESS=vpn.myvpn-domain.com
+#      - SERVER_ADDRESS=vpn.myvpn-domain.com
       - SERVER_PORT=51194
       - PROTO=udp
       - KEY_COUNTRY=HU
@@ -20,4 +20,3 @@ services:
     network_mode: "host"
     privileged: true
     restart: always
-

--- a/files/generate-newclient-cert.sh
+++ b/files/generate-newclient-cert.sh
@@ -6,6 +6,7 @@ KeysBaseDir="$EasyRSADir/keys"
 
 ClientConfTemplate="$EasyRSADir/templates/client.conf"
 ServerCAFile="/etc/openvpn/ca.crt"
+ServerAuthFile="/etc/openvpn/ta.key"
 
 if [ -z "$SERVER_ADDRESS" ]
 then
@@ -57,6 +58,8 @@ sed -i -e "s@^[pP]roto.*@proto $PROTO@g" $ClientConf
 
 #  insert ca
 sed -i '/<ca>/r '"$ServerCAFile"'' $ClientConf
+#  insert tls-auth
+sed -i '/<tls-auth>/r '"$ServerAuthFile"'' $ClientConf
 #  insert cert
 ls -hal $KeysBaseDir/$keyname.crt
 sed -i '/<cert>/r '"$KeysBaseDir/$keyname.crt"'' $ClientConf

--- a/files/start.sh
+++ b/files/start.sh
@@ -37,6 +37,8 @@ then
   mv /etc/template-client.ovpn /etc/openvpn/easy-rsa/templates/client.conf
 fi
 
+# Debian openvpn preconfig
+ln -s -f /etc/openvpn/easy-rsa/openssl-1.0.0.cnf /etc/openvpn/easy-rsa/openssl.cnf
 # server key expire time
 [ -z $SERVER_KEY_EXPIRE ] && { SERVER_KEY_EXPIRE=3650; echo "Using default server key expire time: $SERVER_KEY_EXPIRE days"; }
 # generate vpn server CA cert
@@ -54,6 +56,7 @@ then
   ../build-dh
   ../pkitool --initca
   ../pkitool --server vpnserver
+  openvpn --genkey --secret /etc/openvpn/easy-rsa/keys/ta.key
 fi
 
 echo "Checking revoke list..."
@@ -62,6 +65,7 @@ echo "Checking revoke list..."
 echo "Symlinking configs ..."
 ln -f -s /etc/openvpn/easy-rsa/keys/dh2048.pem /etc/openvpn/dh2048.pem
 ln -f -s /etc/openvpn/easy-rsa/keys/ca.crt /etc/openvpn/ca.crt
+ln -f -s /etc/openvpn/easy-rsa/keys/ta.key /etc/openvpn/ta.key
 ln -f -s /etc/openvpn/easy-rsa/keys/vpnserver.crt /etc/openvpn/server.crt
 ln -f -s /etc/openvpn/easy-rsa/keys/vpnserver.key /etc/openvpn/server.key
 ln -f -s /etc/openvpn/easy-rsa/keys/crl.pem /etc/openvpn/crl.pem

--- a/files/template-client.ovpn
+++ b/files/template-client.ovpn
@@ -89,6 +89,10 @@ persist-tun
 <key>
 </key>
 
+#tls-auth ta.key
+<tls-auth>
+</tls-auth>
+
 # Verify server certificate by checking that the
 # certicate has the correct key usage set.
 # This is an important precaution to protect against
@@ -105,12 +109,14 @@ remote-cert-tls server
 
 # If a tls-auth key is used on the server
 # then every client must also have the key.
-;tls-auth ta.key 1
+tls-auth ta.key 1
 
 # Select a cryptographic cipher.
 # If the cipher option is used on the server
 # then you must also specify it here.
-;cipher x
+# Note that 2.4 client/server will automatically
+# negotiate AES-256-GCM in TLS mode.
+# See also the ncp-cipher option in the manpage
 cipher AES-256-CBC
 
 # Enable compression on the VPN link.

--- a/files/template-client.ovpn
+++ b/files/template-client.ovpn
@@ -109,7 +109,9 @@ remote-cert-tls server
 
 # If a tls-auth key is used on the server
 # then every client must also have the key.
-tls-auth ta.key 1
+#tls-auth ta.key 1
+# If you use inline keys enable tls-auth feature with key-direction
+key-direction 1
 
 # Select a cryptographic cipher.
 # If the cipher option is used on the server


### PR DESCRIPTION
Ubuntu changed to Debian because Debian stable contains the 2.4 version of OpenVPN sooner than Ubuntu LTS
configs and template config files updated to OpenVPN 2.4